### PR TITLE
feeble attempt at variable time stepping for fixed CFL

### DIFF
--- a/core/cmt/CMTDATA
+++ b/core/cmt/CMTDATA
@@ -58,8 +58,8 @@ c---------------------------------------------------------------------
       integer              stage,nstage
       common /tstepstage/ stage,nstage
 
-      real                  tcoef(3,3)     
-      common /timestepcoef/ tcoef
+      real                  tcoef(3,3),dt_cmt,time_cmt
+      common /timestepcoef/ tcoef,dt_cmt,time_cmt
       
       integer            res_freq
       common /cmtioflgs/ res_freq

--- a/short_tests/CMT/inviscid_vortex/SIZE
+++ b/short_tests/CMT/inviscid_vortex/SIZE
@@ -19,7 +19,7 @@ c
       parameter (lelg=5000)     ! max total number of elements
       parameter (lp=1024)       ! max number of MPI ranks
       parameter (lelt=50)       ! max number of elements per MPI rank 
-      parameter (ldimt=4)       ! max number of auxiliary fields (temperature + scalars)
+      parameter (ldimt=3)       ! max number of auxiliary fields (temperature + scalars)
 
       ! OPTIONAL
       parameter (lelx=1,lely=1,lelz=1)          ! global tensor mesh dimensions

--- a/short_tests/CMT/inviscid_vortex/pvort.rea
+++ b/short_tests/CMT/inviscid_vortex/pvort.rea
@@ -12,11 +12,11 @@
    1.00000     p008 CONDUCT
    0.00000     p009
    0.00000     p010 FINTIME
-  10000.0     p011 NSTEPS
- -0.100000E-02 p012 DT
+  10000.0      p011 NSTEPS
+ 1.000000E-03 p012 DT
    0.00000     p013 IOCOMM
    0.00000     p014 IOTIME
-   10000.00     p015 IOSTEP
+  1000.00     p015 IOSTEP
    0.00000     p016 PSSOLVER: 0=default
    1.00000     p017
   0.500000E-01 p018 GRID < 0 --> # cells on screen
@@ -27,7 +27,7 @@
   0              p23 NPSCAL
   0.100000E-09 p024 TOLREL
   0.100000E-04 p025 TOLABS
-   1.00000     p026 COURANT/NTAU
+   0.00000     p026 COURANT/NTAU
    3.00000     p027 TORDER
    0.00000     p028 TORDER: mesh velocity (0: p28=p27)
    0.00000     p029 = magnetic visc if > 0, = -1/Rm if < 0
@@ -133,7 +133,7 @@
  F F T T T T T T T T T T  IFTMSH (IF mesh for this field is T mesh)
  F      IFAXIS
  F      IFSTRS
- F      IFSPLIT
+ T      IFSPLIT
  F      IFMGRID
  F      IFMODEL
  F      IFKEPS

--- a/short_tests/CMT/inviscid_vortex/pvort.usr
+++ b/short_tests/CMT/inviscid_vortex/pvort.usr
@@ -1,6 +1,7 @@
       subroutine userchk
       include 'SIZE'
       include 'TOTAL'
+      include 'CMTDATA'
       parameter (lt=lx1*ly1*lz1*lelt)
       common /mystuff/ vrt(lt,3),wk1(lt),wk2(lt)
 
@@ -12,6 +13,10 @@
       endif
       ifxyo = .true.
 
+! sigh. need settime to bend to my will
+      time=time_cmt
+      dt=dt_cmt
+
       if (mod(istep,iostep).eq.0) call comp_vort3(vrt,wk1,wk2,vx,vy,vz)
       if (mod(istep,iostep).eq.0) call outpost(vx,vy,vz,vrt,t,'vrt')
 
@@ -22,22 +27,6 @@
 
       subroutine entropy_viscosity
       include 'SIZE'
-      return
-      end
-
-!-----------------------------------------------------------------------
-
-      subroutine cmt_userflux
-      include 'SIZE'
-      include 'TOTAL'
-      include 'NEKUSE' ! probably want to start following nek convention
-                       ! and use this routine pointwise
-      real fluxout(lx1*lz1)
-      integer e,f,eg
-c     e = gllel(eg)
-      do i=1,nx1*nz1
-         fluxout(i)=0.0 ! adiabatic
-      enddo
       return
       end
 
@@ -187,7 +176,12 @@ c-----------------------------------------------------------------------
       res_freq  = 5000000
       flio_freq = 10000
 
-      IFDG=.true.
+      nbc=0
+      do i=1,2 ! get density output
+         call add_temp(f2tbc,nbc,1)
+      enddo
+      igeom=2
+      call setup_topo
 
       return
       end
@@ -259,10 +253,10 @@ c
       enddo
       pi = 4.0*atan(1.0)
       phigic = 1.0
-      num_steps = int(1/dt)
-      xctrnew = xctr + uxinf*time
-      yctrnew = yctr + uyinf*time
-      nloop = int(int(uxinf*time)/10) + 1
+      num_steps = int(1/dt_cmt)
+      xctrnew = xctr + uxinf*time_cmt
+      yctrnew = yctr + uyinf*time_cmt
+      nloop = int(int(uxinf*time_cmt)/10) + 1
       if(xctrnew.gt.10.0)then
          xctrnew = (xctrnew - nloop*10.0)
       endif
@@ -311,10 +305,10 @@ c
          open(unit=22,file="l2norms.dat",form="formatted",
      >        access="append")
          write(22,'(a12,6e17.8)')
-     >          'L2err_norms ',time,(sqrt(sumcvars_l2(i)),i=1,5)
+     >          'L2err_norms ',time_cmt,(sqrt(sumcvars_l2(i)),i=1,5)
          close(22)
       endif
-      if(nio.eq.0) write(6,*)'center location ', time,xctrnew,yctrnew
+      if(nio.eq.0) write(6,*)'center location ',time_cmt,xctrnew,yctrnew
       return
       end
 !-----------------------------------------------------------------------


### PR DESCRIPTION
I would really like to get sound speed into settime without being too disruptive. Oh, and now we are now using the t array to write out cmt-specific quantities (e.g., density) in the default output from prepost instead of spamming a bunch of 5-field files. PRotip: IFSPLIT makes pressure checkpoint correctly. So CMT-nek now needs IFSPLIT=T