### PR TITLE
 reduce memory and ifldmhd workaround in inviscid_vortex example

### DIFF
--- a/core/ic.f
+++ b/core/ic.f
@@ -1686,7 +1686,7 @@ c-----------------------------------------------------------------------
                vx(i,j,k,e) = ux
                vy(i,j,k,e) = uy
                vz(i,j,k,e) = uz
-             elseif (ifield.eq.ifldmhd) then
+             elseif (ifield.eq.ifldmhd .and. ifmhd) then
                bx(i,j,k,e) = ux
                by(i,j,k,e) = uy
                bz(i,j,k,e) = uz

--- a/core/ic.f
+++ b/core/ic.f
@@ -1686,7 +1686,7 @@ c-----------------------------------------------------------------------
                vx(i,j,k,e) = ux
                vy(i,j,k,e) = uy
                vz(i,j,k,e) = uz
-             elseif (ifield.eq.ifldmhd .and. ifmhd) then
+             elseif (ifield.eq.ifldmhd) then
                bx(i,j,k,e) = ux
                by(i,j,k,e) = uy
                bz(i,j,k,e) = uz

--- a/short_tests/CMT/inviscid_vortex/SIZE
+++ b/short_tests/CMT/inviscid_vortex/SIZE
@@ -22,19 +22,19 @@ c
       ! OPTIONAL
       parameter (lhis=1000)            ! max history points
       parameter (maxobj=4)             ! max number of objects
-      parameter (lpert=3)              ! max perturbation modes
+      parameter (lpert=1)              ! max perturbation modes
       parameter (toteq=5)              ! max number of conserved scalars in cmt
       parameter (nsessmax=2)           ! max sessions
       parameter (lxo=lx1)              ! max grid size on output (lxo>=lx1)
       parameter (lelx=1,lely=1,lelz=1) ! global tensor mesh dimensions
-      parameter (mxprev=20,lgmres=30)  ! max dim of projection & Krylov space
+      parameter (mxprev=1,lgmres=1)    ! max dim of projection & Krylov space
       parameter (lorder=3)             ! max order in time
 
       parameter (lelt=lelg/lpmin + 4)  ! max number of local elements per MPI rank
-      parameter (lx1m=lx1)             ! polynomial order mesh solver
-      parameter (lbelt=lelt)           ! mhd
-      parameter (lpelt=lelt)           ! linear stability
-      parameter (lcvelt=lelt)          ! cvode
+      parameter (lx1m=1)               ! polynomial order mesh solver
+      parameter (lbelt=1)              ! mhd
+      parameter (lpelt=1)              ! linear stability
+      parameter (lcvelt=1)             ! cvode
       parameter (lfdm=0)  ! == 1 for fast diagonalization method
 
       ! INTERNALS

--- a/short_tests/CMT/inviscid_vortex/pvort.usr
+++ b/short_tests/CMT/inviscid_vortex/pvort.usr
@@ -190,8 +190,10 @@ c-----------------------------------------------------------------------
       outflsub=.true.
       IFRESTART=.false.
       IFCNTFILT=.false.
-      ifsip=.false.
-      gasmodel=1
+
+! Avoid overstepping bx bounds in nekuic with ldimt>3, lbelt=1
+      ifldmhd=9999
+
       return
       end
 c-----------------------------------------------------------------------


### PR DESCRIPTION
we need to make sure bx is never initialized in nekuic regardless of the value of ldimt, especially for cases with lbelt=1 (which should be all cases). usrdat2 in CMT-nek must have ifldmhd set to an integer larger than any number of T fields we may ever want to look at in the outpost field files, so we now do that in usrdat2