### PR TITLE
Do not initialize bx in nekuic unless ifmhd=.true.

### DIFF
--- a/core/ic.f
+++ b/core/ic.f
@@ -1686,7 +1686,7 @@ c-----------------------------------------------------------------------
                vx(i,j,k,e) = ux
                vy(i,j,k,e) = uy
                vz(i,j,k,e) = uz
-             elseif (ifield.eq.ifldmhd) then
+             elseif (ifield.eq.ifldmhd .and. ifmhd) then
                bx(i,j,k,e) = ux
                by(i,j,k,e) = uy
                bz(i,j,k,e) = uz


### PR DESCRIPTION
This handles cases in which ldimt > npscal + 3, but lbelt=1 and IFMHD=F. This makes it easier to put diagnostic quantities (e.g., artificial viscosity coefficients in CMT-nek) into the T array and thus easier to post-process using files from outpost.